### PR TITLE
fix: default object properties to prevent crash if not defined

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,6 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var TYPE_NAME_VENDOR_PROPERTY_NAME = exports.TYPE_NAME_VENDOR_PROPERTY_NAME = 'x-typeName';

--- a/lib/findMutationsDescriptions.js
+++ b/lib/findMutationsDescriptions.js
@@ -6,6 +6,8 @@ Object.defineProperty(exports, "__esModule", {
 
 var _lodash = require('lodash');
 
+var _constants = require('./constants');
+
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 var findMutationsDescriptions = function findMutationsDescriptions(paths) {
@@ -23,7 +25,7 @@ var findMutationsDescriptions = function findMutationsDescriptions(paths) {
 				return Object.assign({}, acc, _defineProperty({}, operationId, {
 					path: path,
 					inputSchema: inputSchema,
-					schema: schema.title ? schema : Object.assign({}, schema, { title: operationId }),
+					schema: schema.title || schema[_constants.TYPE_NAME_VENDOR_PROPERTY_NAME] ? schema : Object.assign({}, schema, _defineProperty({}, _constants.TYPE_NAME_VENDOR_PROPERTY_NAME, operationId)),
 					// schema,
 					parameters: parameters,
 					operationMethod: lcMethod,

--- a/lib/findQueriesDescriptions.js
+++ b/lib/findQueriesDescriptions.js
@@ -6,6 +6,8 @@ Object.defineProperty(exports, "__esModule", {
 
 var _lodash = require('lodash');
 
+var _constants = require('./constants');
+
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 var findQueriesDescriptions = function findQueriesDescriptions(paths) {
@@ -18,7 +20,7 @@ var findQueriesDescriptions = function findQueriesDescriptions(paths) {
 			if (operationId && schema && method.toLowerCase() === 'get') {
 				return Object.assign({}, acc, _defineProperty({}, operationId, {
 					path: path,
-					schema: schema.title ? schema : Object.assign({}, schema, { title: operationId }),
+					schema: schema.title || schema[_constants.TYPE_NAME_VENDOR_PROPERTY_NAME] ? schema : Object.assign({}, schema, _defineProperty({}, _constants.TYPE_NAME_VENDOR_PROPERTY_NAME, operationId)),
 					// schema,
 					parameters: (0, _lodash.get)(operation, 'parameters', []).concat((0, _lodash.get)(pathMethods, 'parameters', [])),
 					consumes: consumes,

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,8 @@ var _invariant = require('invariant');
 
 var _invariant2 = _interopRequireDefault(_invariant);
 
+var _constants = require('./constants');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
@@ -109,8 +111,8 @@ var checkObjectSchemaForUnsupportedFeatures = function checkObjectSchemaForUnsup
 var extractTypeName = function extractTypeName(nodeContext) {
 	// console.log('nodeContext.node', nodeContext.node.title);
 	var schema = nodeContext.node;
-	if (schema && (0, _lodash.isString)(schema.title)) {
-		return schema.title;
+	if (schema && ((0, _lodash.isString)(schema.title) || (0, _lodash.isString)(schema[_constants.TYPE_NAME_VENDOR_PROPERTY_NAME]))) {
+		return schema[_constants.TYPE_NAME_VENDOR_PROPERTY_NAME] || schema.title;
 	}
 	if (nodeContext.parent && nodeContext.parent.parent && nodeContext.parent.parent.node.type === 'object') {
 		return extractTypeName(nodeContext.parent) + '_' + nodeContext.key;
@@ -258,7 +260,7 @@ var parseInterfaces = function parseInterfaces(_ref2) {
 	    ignoreRequired = _ref2.ignoreRequired;
 
 	(0, _traverse2.default)(rootSchema).forEach(function parseInterface(schema, context) {
-		var isInterface = context.parent && context.parent.key === 'allOf' && schema.type === 'object' && (0, _lodash.isString)(schema.title);
+		var isInterface = context.parent && context.parent.key === 'allOf' && schema.type === 'object' && ((0, _lodash.isString)(schema.title) || (0, _lodash.isString)(schema[_constants.TYPE_NAME_VENDOR_PROPERTY_NAME]));
 		var isCached = schema && schema.$$type;
 		if (isInterface && !isCached) {
 			checkObjectSchemaForUnsupportedFeatures(schema);
@@ -272,7 +274,7 @@ var parseInterfaces = function parseInterfaces(_ref2) {
 			typesCache[schemaId] = new _graphql.GraphQLInterfaceType({
 				name: name,
 				fields: function fields() {
-					return Object.keys(properties).reduce(function (acc, propertyName) {
+					return Object.keys(properties || {}).reduce(function (acc, propertyName) {
 						var propertySchema = properties[propertyName];
 						var type = scalarTypeFromSchema(propertySchema);
 						if (!type) {
@@ -347,7 +349,7 @@ var parseObjectTypes = function parseObjectTypes(_ref3) {
 					return true;
 				},
 				fields: function fields() {
-					return Object.keys(properties).filter(function (propertyName) {
+					return Object.keys(properties || {}).filter(function (propertyName) {
 						return propertyName !== discriminatorFieldName;
 					}).reduce(function (acc, propertyName) {
 						var propertySchema = properties[propertyName];
@@ -473,7 +475,7 @@ var constructInputType = function constructInputType(_ref5) {
 		inputType = new _graphqlUnionInputType2.default({
 			name: typeName,
 			inputTypes: (0, _lodash.reduce)(schema.anyOf, function (acc, unionPartSchema) {
-				return Object.assign({}, acc, _defineProperty({}, unionPartSchema.title, constructInputType({
+				return Object.assign({}, acc, _defineProperty({}, unionPartSchema[_constants.TYPE_NAME_VENDOR_PROPERTY_NAME] || unionPartSchema.title, constructInputType({
 					schema: unionPartSchema,
 					typesCache: typesCache,
 					isNestedUnderEntity: isNestedUnderEntity,
@@ -491,7 +493,7 @@ var constructInputType = function constructInputType(_ref5) {
 		    properties = _mergeAllOf3.properties,
 		    required = _mergeAllOf3.required;
 
-		var hasID = Object.keys(properties).reduce(function (acc, pn) {
+		var hasID = Object.keys(properties || {}).reduce(function (acc, pn) {
 			return acc || isIdSchema(properties[pn]);
 		}, false);
 		// const requireOnlyIdInput = hasID && isNestedUnderEntity;
@@ -534,7 +536,7 @@ var parseRootInputTypes = function parseRootInputTypes(_ref6) {
 		var isCachedRootInputType = schema.$$rootInputType;
 		if (isRootInputType && !isCachedRootInputType) {
 			schema.$$rootInputType = Symbol(TYPE_SCHEMA_SYMBOL_LABEL);
-			var typeName = schema.title || 'Mutation_' + context.parent.parent.parent.node.operationId;
+			var typeName = schema[_constants.TYPE_NAME_VENDOR_PROPERTY_NAME] || schema.title || 'Mutation_' + context.parent.parent.parent.node.operationId;
 			typesCache[schema.$$rootInputType] = constructInputType({
 				schema: schema,
 				typesCache: typesCache,
@@ -588,7 +590,7 @@ var parseInputUnions = function parseInputUnions(_ref8) {
 			typesCache[schemaId] = new _graphqlUnionInputType2.default({
 				name: extractTypeName(context) + 'Input',
 				inputTypes: (0, _lodash.reduce)(schema.anyOf, function (acc, subSchema) {
-					return Object.assign({}, acc, _defineProperty({}, subSchema.title, typesCache[subSchema.$$inputType]));
+					return Object.assign({}, acc, _defineProperty({}, subSchema[_constants.TYPE_NAME_VENDOR_PROPERTY_NAME] || subSchema.title, typesCache[subSchema.$$inputType]));
 				}, {}),
 				typeKey: discriminatorFieldName
 			});
@@ -644,6 +646,8 @@ var parseInputLists = function parseInputLists(_ref10) {
 };
 
 var swaggerToSchema = function swaggerToSchema() {
+	var _Query, _Mutation;
+
 	var _ref11 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
 	    paths = _ref11.swagger.paths,
 	    swagger = _ref11.swagger,
@@ -659,30 +663,18 @@ var swaggerToSchema = function swaggerToSchema() {
 
 	var completeSchema = Object.assign({}, swagger, {
 		definitions: Object.assign({}, swagger.definitions || {}, {
-			Query: {
-				title: 'Query',
-				type: 'object',
-				description: 'query root type',
-				properties: (0, _lodash.mapValues)(queriesDescriptions, function (_ref12) {
-					var schema = _ref12.schema;
-					return schema;
-				}),
-				'x-links': (0, _lodash.mapValues)(queriesDescriptions, function (_, linkName) {
-					return linkName;
-				})
-			},
-			Mutation: {
-				title: 'Mutation',
-				type: 'object',
-				description: 'mutation root type',
-				properties: (0, _lodash.mapValues)(mutationsDescriptions, function (_ref13) {
-					var schema = _ref13.schema;
-					return schema;
-				}),
-				'x-links': (0, _lodash.mapValues)(mutationsDescriptions, function (_, linkName) {
-					return linkName;
-				})
-			}
+			Query: (_Query = {}, _defineProperty(_Query, _constants.TYPE_NAME_VENDOR_PROPERTY_NAME, 'Query'), _defineProperty(_Query, 'type', 'object'), _defineProperty(_Query, 'description', 'query root type'), _defineProperty(_Query, 'properties', (0, _lodash.mapValues)(queriesDescriptions, function (_ref12) {
+				var schema = _ref12.schema;
+				return schema;
+			})), _defineProperty(_Query, 'x-links', (0, _lodash.mapValues)(queriesDescriptions, function (_, linkName) {
+				return linkName;
+			})), _Query),
+			Mutation: (_Mutation = {}, _defineProperty(_Mutation, _constants.TYPE_NAME_VENDOR_PROPERTY_NAME, 'Mutation'), _defineProperty(_Mutation, 'type', 'object'), _defineProperty(_Mutation, 'description', 'mutation root type'), _defineProperty(_Mutation, 'properties', (0, _lodash.mapValues)(mutationsDescriptions, function (_ref13) {
+				var schema = _ref13.schema;
+				return schema;
+			})), _defineProperty(_Mutation, 'x-links', (0, _lodash.mapValues)(mutationsDescriptions, function (_, linkName) {
+				return linkName;
+			})), _Mutation)
 		})
 	});
 

--- a/src/index.js
+++ b/src/index.js
@@ -265,7 +265,7 @@ const parseInterfaces = ({ schema: rootSchema, apiDefinition, operations, types:
 				typesCache[schemaId] = new GraphQLInterfaceType(
 					{
 						name,
-						fields: () => Object.keys(properties).reduce(
+						fields: () => Object.keys(properties || {}).reduce(
 							(acc, propertyName) => {
 								const propertySchema = properties[propertyName];
 								let type = scalarTypeFromSchema(propertySchema);
@@ -338,7 +338,7 @@ const parseObjectTypes = ({ schema: rootSchema, apiDefinition, operations, types
 							}
 							return true;
 						},
-						fields: () => Object.keys(properties).filter(propertyName => propertyName !== discriminatorFieldName).reduce(
+						fields: () => Object.keys(properties || {}).filter(propertyName => propertyName !== discriminatorFieldName).reduce(
 							(acc, propertyName) => {
 								const propertySchema = properties[propertyName];
 								let type = scalarTypeFromSchema(propertySchema);
@@ -493,7 +493,7 @@ const constructInputType = ({ schema, typeName: inputTypeName, typesCache, isNes
 		schema[IS_IN_INPUT_TYPE_CHAIN_SYMBOL] = true;
 		const { properties, required } = mergeAllOf(schema);
 
-		const hasID = Object.keys(properties).reduce((acc, pn) => acc || isIdSchema(properties[pn]), false);
+		const hasID = Object.keys(properties || {}).reduce((acc, pn) => acc || isIdSchema(properties[pn]), false);
 		// const requireOnlyIdInput = hasID && isNestedUnderEntity;
 
 		inputType = new GraphQLInputObjectType(


### PR DESCRIPTION
Was having an issue whereby the conversion would crashed because a couple of the definitions of type: `object` had no associated `properties` in my swagger definition.

```
(node:49292) UnhandledPromiseRejectionWarning: TypeError: Cannot convert undefined or null to object
```

Resolution for this was to default properties to `{}`

Essentially:
`Object.keys(properties || {})` instead of `Object.keys(properties)`